### PR TITLE
解决了容器通过css设置 transform:scale() 后 拖动过程中鼠标位置不正确的问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,8 +12,12 @@
     <div>
       h: {{ h }}<button @click="h += 10">+</button><button @click="h -= 10">-</button>
     </div>
+     <div>
+      scale:{{scale}} 滚动鼠标滚轮缩放画布
+     </div>
+
     <div>active:{{ active }}<br /></div>
-    <div class="parent">
+    <div class="parent" :style="{transform:'scale('+scale+')'}">
       <Vue3DraggableResizable
         :initW="40"
         :initH="80"
@@ -29,7 +33,10 @@
         :disabledW="false"
         :disabledH="false"
         :disabledY="false"
-        :lockAspectRatio="true"
+        :lockAspectRatio="false"
+        :parent-scale-x="scale"
+        :parent-scale-y="scale"
+
         classNameHandle="my-handle"
         @activated="print('activated')"
         @deactivated="print('deactivated')"
@@ -46,7 +53,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import Vue3DraggableResizable from "./components/Vue3DraggableResizable";
 import DraggableContainer from "./components/DraggableContainer";
@@ -62,10 +69,25 @@ export default defineComponent({
       active: false,
       draggable: true,
       resizable: true,
+      scale:1
     };
   },
-  mounted() {},
+  mounted() {
+    //@ts-ignore
+    window.addEventListener("mousewheel",this.mousewheel,false)
+  },
   methods: {
+    mousewheel(e:WheelEvent){
+        if(e.deltaY<0){
+          if(this.scale<1){
+            this.scale = Math.fround((this.scale+0.1)*100)/100
+          }
+        }else{
+           if(this.scale>0.1){
+            this.scale = Math.fround((this.scale-0.1)*100)/100
+          }
+        }
+    },
     print(val, e) {
       // console.log(val, e)
     },
@@ -73,9 +95,12 @@ export default defineComponent({
 });
 </script>
 <style lang="less" scoped>
+#app{
+  padding: 50px;
+}
 .parent {
-  width: 300px;
-  height: 300px;
+  width: 1000px;
+  height: 500px;
   // position: absolute;
   // top: 100px;
   // left: 200px;

--- a/src/components/Vue3DraggableResizable.ts
+++ b/src/components/Vue3DraggableResizable.ts
@@ -127,6 +127,14 @@ const VdrProps = {
   lockAspectRatio: {
     type: Boolean,
     default: false
+  },
+  parentScaleX:{
+    type:Number,
+    default:1
+  },
+  parentScaleY:{
+    type:Number,
+    default:1
   }
 }
 

--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -38,6 +38,8 @@ export function initState(props: any, emit: any) {
   const [resizingMaxHeight, setResizingMaxHeight] = useState<number>(Infinity)
   const [resizingMinWidth, setResizingMinWidth] = useState<number>(props.minW)
   const [resizingMinHeight, setResizingMinHeight] = useState<number>(props.minH)
+  const [parentScaleX,setParentScaleX] = useState<number>(props.parentScaleX)
+  const [parentScaleY,setParentScaleY] = useState<number>(props.parentScaleY)
   const aspectRatio = computed(() => height.value / width.value)
   watch(
     width,
@@ -73,6 +75,12 @@ export function initState(props: any, emit: any) {
       setEnable(newVal)
     }
   )
+  watch(()=>props.parentScaleX,()=>{
+      setParentScaleX(props.parentScaleX)
+  })
+  watch(()=>props.parentScaleY,()=>{
+    setParentScaleY(props.parentScaleY)
+  })
   return {
     id: getId(),
     width,
@@ -88,6 +96,8 @@ export function initState(props: any, emit: any) {
     resizingMinWidth,
     resizingMinHeight,
     aspectRatio,
+    parentScaleX,
+    parentScaleY,
     setEnable,
     setDragging,
     setResizing,
@@ -99,7 +109,8 @@ export function initState(props: any, emit: any) {
     $setWidth: (val: number) => setWidth(Math.floor(val)),
     $setHeight: (val: number) => setHeight(Math.floor(val)),
     $setTop: (val: number) => setTop(Math.floor(val)),
-    $setLeft: (val: number) => setLeft(Math.floor(val))
+    $setLeft: (val: number) => setLeft(Math.floor(val)),
+    
   }
 }
 
@@ -248,7 +259,9 @@ export function initDraggableContainer(
     setDragging,
     setEnable,
     setResizing,
-    setResizingHandle
+    setResizingHandle,
+    parentScaleX,
+    parentScaleY
   } = containerProps
   const { setTop, setLeft } = limitProps
   let lstX = 0
@@ -287,8 +300,8 @@ export function initDraggableContainer(
     e.preventDefault()
     if (!(dragging.value && containerRef.value)) return
     const [pageX, pageY] = getPosition(e)
-    const deltaX = pageX - lstPageX
-    const deltaY = pageY - lstPageY
+    const deltaX = (pageX - lstPageX)/parentScaleX.value
+    const deltaY = (pageY - lstPageY)/parentScaleY.value
     let newLeft = lstX + deltaX
     let newTop = lstY + deltaY
     if (referenceLineMap !== null) {


### PR DESCRIPTION
解决了容器通过css设置 transform:scale() 后 拖动过程中鼠标位置不正确的问题