### PR TITLE
Change css border to outline, Set cursor to move

### DIFF
--- a/src/components/index.css
+++ b/src/components/index.css
@@ -5,6 +5,7 @@
 .vdr-container.active {
   outline-color: #000;
   outline-style: dashed;
+  cursor:move;
 }
 .vdr-container.dragging {
   outline-color: #000;

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -1,15 +1,14 @@
 .vdr-container {
   position: absolute;
-  border: 1px solid transparent;
-  box-sizing: border-box;
+  outline: 1px solid transparent;
 }
 .vdr-container.active {
-  border-color: #000;
-  border-style: dashed;
+  outline-color: #000;
+  outline-style: dashed;
 }
 .vdr-container.dragging {
-  border-color: #000;
-  border-style: solid;
+  outline-color: #000;
+  outline-style: solid;
 }
 .vdr-handle {
   box-sizing: border-box;


### PR DESCRIPTION
although `box-sizing` was set to `border-box` which did a similar effect, i think its better to use `outline` https://developer.mozilla.org/en-US/docs/Web/CSS/outline

it seems that it's supported 97.48% so that is not a problem https://caniuse.com/?search=outline

also i added css to set cursor to move when mouse is hovering on a active container